### PR TITLE
`asyncEmit` method

### DIFF
--- a/src/signal.js
+++ b/src/signal.js
@@ -181,7 +181,7 @@ export default class Signal {
     }
 
     this.emited++
-    return Promise.all(promises)
+    return Promise.allSettled(promises)
   }
 
   /**

--- a/src/signal.js
+++ b/src/signal.js
@@ -156,6 +156,35 @@ export default class Signal {
   }
 
   /**
+   * Emit signal with possibility to await all listeners executions to finish
+   * @param {...any} args - Arguments to pass to listeners
+   * @returns {Promise} - Resolves when all listeners for this signal finished running
+   */
+  async asyncEmit () {
+    this.stopped = false
+
+    let i = this.binds.length
+
+    if (this.memorable) this.args = arguments
+
+    const promises = []
+    while (i--) {
+      const bind = this.binds[i]
+      const result = bind.fn(...arguments)
+      promises.push(result)
+      bind.fired++
+      if (bind.once) this.binds.splice(i, 1)
+      if (this.stopped) {
+        this.stopped = false
+        return
+      }
+    }
+
+    this.emited++
+    return Promise.all(promises)
+  }
+
+  /**
    * Clear stored arguments and emission count (keeps listeners)
    */
   forget () {

--- a/test.js
+++ b/test.js
@@ -9,6 +9,7 @@ runner([
   { script: './tests/late.js' },
   { script: './tests/late-memory.js' },
   { script: './tests/nested.js' },
+  { script: './tests/async-emit.js' },
   { script: './tests/forget.js' },
   { script: './tests/wipe.js' },
   { script: './tests/break.js' },

--- a/tests/async-emit.js
+++ b/tests/async-emit.js
@@ -1,7 +1,7 @@
 import { execute } from 'test-a-bit'
 import Signal      from '../src/signal.js'
 
-execute('await .asyncEmit() with 2 async binds', async (success, fail) => {
+execute('await .asyncEmit() with 3 async binds (2 resolve 1 rejects)', async (success, fail) => {
   const sig = new Signal()
   let asyncResult1 = 'no beep :('
   let asyncResult2 = 'no boop :('
@@ -9,6 +9,10 @@ execute('await .asyncEmit() with 2 async binds', async (success, fail) => {
   sig.on(async () => {
     await new Promise(resolve => setTimeout(resolve, 100))
     asyncResult1 = 'beep'
+  })
+
+  sig.on(async () => {
+    await new Promise((resolve, reject) => setTimeout(reject, 150))
   })
 
   sig.on(async () => {

--- a/tests/async-emit.js
+++ b/tests/async-emit.js
@@ -1,0 +1,24 @@
+import { execute } from 'test-a-bit'
+import Signal      from '../src/signal.js'
+
+execute('await .asyncEmit() with 2 async binds', async (success, fail) => {
+  const sig = new Signal()
+  let asyncResult1 = 'no beep :('
+  let asyncResult2 = 'no boop :('
+
+  sig.on(async () => {
+    await new Promise(resolve => setTimeout(resolve, 100))
+    asyncResult1 = 'beep'
+  })
+
+  sig.on(async () => {
+    await new Promise(resolve => setTimeout(resolve, 200))
+    asyncResult2 = 'boop'
+  })
+
+  await sig.asyncEmit()
+
+  asyncResult1 === 'beep' && asyncResult2 === 'boop'
+      ? success('.asyncEmit() works')
+      : fail('.asyncEmit() not working')
+})


### PR DESCRIPTION
The purpose of the new `asyncEmit` method is to be able to wait for all binds to finish running when emitting.

Usage:
```javascript
const sig = new Signal()

sig.on(someAsyncFunction)
sig.on(anotherAsyncFunction)

await sig.asyncEmit() // Promise.allSettled() under the hood, will never throw
```